### PR TITLE
Add typing support for flag-supporting client and tests

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -9,6 +9,7 @@ disallow_subclassing_any = True
 disallow_untyped_calls = True
 disallow_untyped_decorators = True
 disallow_untyped_defs = True
+enable_error_code = redundant-expr, truthy-bool, ignore-without-code, unused-awaitable
 implicit_reexport = False
 no_implicit_optional = True
 show_error_codes = True
@@ -21,12 +22,6 @@ disallow_any_unimported = True
 warn_return_any = True
 
 [mypy-tests.*]
-disallow_any_decorated = False
-disallow_untyped_calls = False
-disallow_untyped_defs = False
-
-[mypy-aiomcache.client]
-# TODO: Remove once decorator can be typed correctly.
 disallow_any_decorated = False
 
 

--- a/aiomcache/__init__.py
+++ b/aiomcache/__init__.py
@@ -9,9 +9,9 @@ Usage example::
     await mc.delete("another_key")
 """
 
-from .client import Client
+from .client import Client, FlagClient
 from .exceptions import ClientException, ValidationException
 
-__all__ = ('Client', 'ClientException', 'ValidationException')
+__all__ = ("Client", "ClientException", "FlagClient", "ValidationException")
 
 __version__ = "0.7.0"

--- a/aiomcache/client.py
+++ b/aiomcache/client.py
@@ -1,12 +1,17 @@
 import functools
 import re
 import sys
-from typing import (Any, Awaitable, Callable, Dict, Generic, Literal, Optional, Tuple,
-                    TypeVar, Union, overload)
+from typing import (Any, Awaitable, Callable, Dict, Generic, Optional, Tuple, TypeVar,
+                    Union, overload)
 
 from . import constants as const
 from .exceptions import ClientException, ValidationException
 from .pool import Connection, MemcachePool
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 if sys.version_info >= (3, 10):
     from typing import Concatenate, ParamSpec

--- a/aiomcache/client.py
+++ b/aiomcache/client.py
@@ -1,7 +1,13 @@
 import functools
 import re
-from typing import Any, Awaitable, Callable, Dict, Optional, Tuple, TypeVar, overload, \
-    Union, Generic
+import sys
+from typing import (Any, Awaitable, Callable, Dict, Generic, Literal, Optional, Tuple,
+                    TypeVar, Union, overload)
+
+if sys.version_info < (3, 10):
+    from typing_extensions import Concatenate, ParamSpec
+else:
+    from typing import Concatenate, ParamSpec
 
 from . import constants as const
 from .exceptions import ClientException, ValidationException
@@ -9,19 +15,20 @@ from .pool import Connection, MemcachePool
 
 __all__ = ['Client']
 
+_P = ParamSpec("_P")
 _T = TypeVar("_T")
-_FlagT = TypeVar("_FlagT")
-_ClientT = Union[bytes, _FlagT]
-_Result = Tuple[Dict[bytes, _ClientT], Dict[bytes, Optional[int]]]
+_U = TypeVar("_U")
+_Client = TypeVar("_Client", bound="FlagClient[Any]")
+_Result = Tuple[Dict[bytes, Union[bytes, _T]], Dict[bytes, _U]]
 
-_get_flag_callable = Callable[[bytes, int], Awaitable[_FlagT]]
-_set_flag_callable = Callable[[_FlagT], Awaitable[Tuple[bytes, int]]]
+_GetFlagHandler = Callable[[bytes, int], Awaitable[_T]]
+_SetFlagHandler = Callable[[_T], Awaitable[Tuple[bytes, int]]]
 
 
-def acquire(func: Callable[..., Awaitable[_T]]) -> Callable[..., Awaitable[_T]]:
+def acquire(func: Callable[Concatenate[_Client, Connection, _P], Awaitable[_T]]) -> Callable[Concatenate[_Client, _P], Awaitable[_T]]:
 
     @functools.wraps(func)
-    async def wrapper(self: "Client[_FlagT]", *args: Any, **kwargs: Any) -> _T:
+    async def wrapper(self: "_Client", *args: _P.args, **kwargs: _P.kwargs) -> _T:  # type: ignore[misc]
         conn = await self._pool.acquire()
         try:
             return await func(self, conn, *args, **kwargs)
@@ -34,12 +41,11 @@ def acquire(func: Callable[..., Awaitable[_T]]) -> Callable[..., Awaitable[_T]]:
     return wrapper
 
 
-class Client(Generic[_FlagT]):
-
+class FlagClient(Generic[_T]):
     def __init__(self, host: str, port: int = 11211, *,
                  pool_size: int = 2, pool_minsize: Optional[int] = None,
-                 get_flag_handler: Optional[_get_flag_callable] = None,
-                 set_flag_handler: Optional[_set_flag_callable] = None):
+                 get_flag_handler: Optional[_GetFlagHandler[_T]] = None,
+                 set_flag_handler: Optional[_SetFlagHandler[_T]] = None):
         """
         Creates new Client instance.
 
@@ -100,7 +106,16 @@ class Client(Generic[_FlagT]):
         """Closes the sockets if its open."""
         await self._pool.clear()
 
-    async def _multi_get(self, conn: Connection, *keys: bytes, with_cas: bool = True) -> _Result:
+    @overload
+    async def _multi_get(self, conn: Connection, *keys: bytes, with_cas: Literal[True] = ...) -> _Result[_T, int]:
+        ...
+
+    @overload
+    async def _multi_get(self, conn: Connection, *keys: bytes, with_cas: Literal[False]) -> _Result[_T, None]:
+        ...
+
+    async def _multi_get(  # type: ignore[misc]
+        self, conn: Connection, *keys: bytes, with_cas: bool = True) -> _Result[_T, Optional[int]]:
         # req  - get <key> [<key> ...]\r\n
         # resp - VALUE <key> <flags> <bytes> [<cas unique>]\r\n
         #        <data block>\r\n (if exists)
@@ -128,7 +143,7 @@ class Client(Generic[_FlagT]):
                 flags = int(terms[2])
                 length = int(terms[3])
 
-                val = (await conn.reader.readexactly(length+2))[:-2]
+                val_bytes = (await conn.reader.readexactly(length+2))[:-2]
                 if key in received:
                     raise ClientException('duplicate results from server')
 
@@ -136,7 +151,9 @@ class Client(Generic[_FlagT]):
                     if not self._get_flag_handler:
                         raise ClientException('received flags without handler')
 
-                    val = await self._get_flag_handler(val, flags)
+                    val: Union[bytes, _T] = await self._get_flag_handler(val_bytes, flags)
+                else:
+                    val = val_bytes
 
                 received[key] = val
                 cas_tokens[key] = int(terms[4]) if with_cas else None
@@ -170,17 +187,18 @@ class Client(Generic[_FlagT]):
         return response == const.DELETED
 
     @overload
-    async def get(self, conn: Connection, key: bytes) -> Optional[bytes]:
+    async def get(self, key: bytes, default: None = ...) -> Union[bytes, _T, None]:
         ...
 
     @overload
-    async def get(self, conn: Connection, key: bytes, default: bytes) -> bytes:
+    async def get(self, key: bytes, default: _U) -> Union[bytes, _T, _U]:
         ...
 
-    @acquire
+    # Mypy bug: https://github.com/python/mypy/issues/12716
+    @acquire  # type: ignore[misc]
     async def get(
-        self, conn: Connection, key: bytes, default: Optional[bytes] = None
-    ) -> Optional[_ClientT]:
+        self, conn: Connection, key: bytes, default: Optional[_U] = None
+    ) -> Union[bytes, _T, _U, None]:
         """Gets a single value from the server.
 
         :param conn: ``Connection``, is the connection to use
@@ -194,7 +212,7 @@ class Client(Generic[_FlagT]):
     @acquire
     async def gets(
         self, conn: Connection, key: bytes, default: Optional[bytes] = None
-    ) -> Tuple[Optional[_ClientT], Optional[int]]:
+    ) -> Tuple[Union[bytes, _T, None], Optional[int]]:
         """Gets a single value from the server together with the cas token.
 
         :param conn: ``Connection``, is the connection to use
@@ -206,7 +224,7 @@ class Client(Generic[_FlagT]):
         return values.get(key, default), cas_tokens.get(key)
 
     @acquire
-    async def multi_get(self, conn: Connection, *keys: bytes) -> Tuple[Optional[_ClientT], ...]:
+    async def multi_get(self, conn: Connection, *keys: bytes) -> Tuple[Union[bytes, _T, None], ...]:
         """Takes a list of keys and returns a list of values.
 
         :param conn: ``Connection``, is the connection to use
@@ -251,8 +269,8 @@ class Client(Generic[_FlagT]):
         return result
 
     async def _storage_command(self, conn: Connection, command: bytes, key: bytes,
-                               value: _ClientT, flags: int = 0, exptime: int = 0,
-                               cas: Optional[bytes] = None) -> bool:
+                               value: Union[bytes, _T], flags: int = 0, exptime: int = 0,
+                               cas: Optional[int] = None) -> bool:
         # req  - set <key> <flags> <exptime> <bytes> [noreply]\r\n
         #        <data block>\r\n
         # resp - STORED\r\n (or others)
@@ -287,7 +305,7 @@ class Client(Generic[_FlagT]):
         return resp == const.STORED
 
     @acquire
-    async def set(self, conn: Connection, key: bytes, value: _ClientT, exptime: int = 0) -> bool:
+    async def set(self, conn: Connection, key: bytes, value: Union[bytes, _T], exptime: int = 0) -> bool:
         """Sets a key to a value on the server
         with an optional exptime (0 means don't auto-expire)
 
@@ -301,7 +319,7 @@ class Client(Generic[_FlagT]):
         return await self._storage_command(conn, b"set", key, value, flags, exptime)
 
     @acquire
-    async def cas(self, conn: Connection, key: bytes, value: _ClientT, cas_token: bytes,
+    async def cas(self, conn: Connection, key: bytes, value: Union[bytes, _T], cas_token: int,
                   exptime: int = 0) -> bool:
         """Sets a key to a value on the server
         with an optional exptime (0 means don't auto-expire)
@@ -320,7 +338,7 @@ class Client(Generic[_FlagT]):
         return await self._storage_command(conn, b"cas", key, value, flags, exptime, cas=cas_token)
 
     @acquire
-    async def add(self, conn: Connection, key: bytes, value: _ClientT, exptime: int = 0) -> bool:
+    async def add(self, conn: Connection, key: bytes, value: Union[bytes, _T], exptime: int = 0) -> bool:
         """Store this data, but only if the server *doesn't* already
         hold data for this key.
 
@@ -335,7 +353,7 @@ class Client(Generic[_FlagT]):
         return await self._storage_command(conn, b"add", key, value, flags, exptime)
 
     @acquire
-    async def replace(self, conn: Connection, key: bytes, value: _ClientT, exptime: int = 0) -> bool:
+    async def replace(self, conn: Connection, key: bytes, value: Union[bytes, _T], exptime: int = 0) -> bool:
         """Store this data, but only if the server *does*
         already hold data for this key.
 
@@ -350,7 +368,7 @@ class Client(Generic[_FlagT]):
         return await self._storage_command(conn, b"replace", key, value, flags, exptime)
 
     @acquire
-    async def append(self, conn: Connection, key: bytes, value: _ClientT, exptime: int = 0) -> bool:
+    async def append(self, conn: Connection, key: bytes, value: Union[bytes, _T], exptime: int = 0) -> bool:
         """Add data to an existing key after existing data
 
         :param conn: ``Connection``, is the connection to use
@@ -466,3 +484,10 @@ class Client(Generic[_FlagT]):
 
         if const.OK != response:
             raise ClientException('Memcached flush_all failed', response)
+
+
+class Client(FlagClient[bytes]):
+    def __init__(self, host: str, port: int = 11211, *,
+                 pool_size: int = 2, pool_minsize: Optional[int] = None):
+        super().__init__(host, port, pool_size=pool_size, pool_minsize=pool_minsize,
+                         get_flag_handler=None, set_flag_handler=None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 docker-py==1.10.6
-mypy==0.942
+mypy==0.950
 pytest==7.1.1
 pytest-asyncio==0.18.3
 pytest-cov==3.0.0

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(name='aiomcache',
       license='BSD',
       packages=find_packages(),
       python_requires='>=3.7',
-      install_requires=(),
+      install_requires=("typing_extensions>=4;python_version<3.10"),
       tests_require=("nose",),
       test_suite='nose.collector',
       include_package_data=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import socket
 import time
 import uuid
 import sys
-from typing import Any, AsyncIterator, Callable, Iterator, TypedDict
+from typing import Any, AsyncIterator, Callable, Iterator
 
 import docker as docker_mod
 import memcache
@@ -11,6 +11,11 @@ import pytest
 
 import aiomcache
 from aiomcache.helpers import pylibmc_get_flag_handler, pylibmc_set_flag_handler
+
+if sys.version_info < (3, 8):
+    from typing_extensions import TypedDict
+else:
+    from typing import TypedDict
 
 if sys.version_info < (3, 11):
     from typing_extensions import NotRequired

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,7 @@ def mcache_server_actual(host: str, port: int = 11211) -> ServerParams:
 
 @contextlib.contextmanager
 def mcache_server_docker(  # type: ignore[no-any-unimported]
-        unused_port: Callable[[], int], docker: docker_mod.DockerClient, session_id: str
+        unused_port: Callable[[], int], docker: docker_mod.Client, session_id: str
     ) -> Iterator[ServerParams]:
     docker.images.pull("memcached:alpine")
     container = docker.containers.run(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ def session_id() -> str:
 
 
 @pytest.fixture(scope='session')
-def docker() -> docker_mod.DockerClient:  # type: ignore[no-any-unimported]
+def docker() -> docker_mod.Client:  # type: ignore[no-any-unimported]
     return docker_mod.from_env()
 
 
@@ -131,7 +131,7 @@ async def mcache(mcache_params: McacheParams) -> AsyncIterator[aiomcache.Client]
     await client.close()
 
 
-@pytest.yield_fixture  # type: ignore[misc]
+@pytest.fixture
 async def mcache_pylibmc(mcache_params: McacheParams) -> AsyncIterator[aiomcache.FlagClient[Any]]:
     client = aiomcache.FlagClient(
         get_flag_handler=pylibmc_get_flag_handler,

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -3,19 +3,21 @@ import random
 
 import pytest
 
-from aiomcache.client import acquire
+from aiomcache.client import acquire, Client
 from aiomcache.pool import Connection, MemcachePool
+
+from .conftest import McacheParams
 
 
 @pytest.mark.asyncio
-async def test_pool_creation(mcache_params):
+async def test_pool_creation(mcache_params: McacheParams) -> None:
     pool = MemcachePool(minsize=1, maxsize=5, **mcache_params)
     assert pool.size() == 0
     assert pool._minsize == 1
 
 
 @pytest.mark.asyncio
-async def test_pool_acquire_release(mcache_params):
+async def test_pool_acquire_release(mcache_params: McacheParams) -> None:
     pool = MemcachePool(minsize=1, maxsize=5, **mcache_params)
     conn = await pool.acquire()
     assert isinstance(conn.reader, asyncio.StreamReader)
@@ -24,7 +26,7 @@ async def test_pool_acquire_release(mcache_params):
 
 
 @pytest.mark.asyncio
-async def test_pool_acquire_release2(mcache_params):
+async def test_pool_acquire_release2(mcache_params: McacheParams) -> None:
     pool = MemcachePool(minsize=1, maxsize=5, **mcache_params)
     reader, writer = await asyncio.open_connection(
         mcache_params["host"], mcache_params["port"])
@@ -39,7 +41,7 @@ async def test_pool_acquire_release2(mcache_params):
 
 
 @pytest.mark.asyncio
-async def test_pool_clear(mcache_params):
+async def test_pool_clear(mcache_params: McacheParams) -> None:
     pool = MemcachePool(minsize=1, maxsize=5, **mcache_params)
     conn = await pool.acquire()
     pool.release(conn)
@@ -50,8 +52,8 @@ async def test_pool_clear(mcache_params):
 
 @pytest.mark.asyncio
 async def test_acquire_dont_create_new_connection_if_have_conn_in_pool(
-    mcache_params,
-):
+    mcache_params: McacheParams,
+) -> None:
     pool = MemcachePool(minsize=1, maxsize=5, **mcache_params)
     assert pool.size() == 0
 
@@ -67,7 +69,7 @@ async def test_acquire_dont_create_new_connection_if_have_conn_in_pool(
 
 
 @pytest.mark.asyncio
-async def test_acquire_limit_maxsize(mcache_params):
+async def test_acquire_limit_maxsize(mcache_params: McacheParams) -> None:
     pool = MemcachePool(minsize=1, maxsize=1, **mcache_params)
     assert pool.size() == 0
 
@@ -76,7 +78,7 @@ async def test_acquire_limit_maxsize(mcache_params):
     assert pool.size() == 1
     pool.release(_conn)
 
-    async def acquire_wait_release():
+    async def acquire_wait_release() -> None:
         conn = await pool.acquire()
         assert conn is _conn
         await asyncio.sleep(0.01)
@@ -92,24 +94,22 @@ async def test_acquire_limit_maxsize(mcache_params):
 
 
 @pytest.mark.asyncio
-async def test_acquire_task_cancellation(
-    mcache_params,
-):
+async def test_acquire_task_cancellation(mcache_params: McacheParams) -> None:
 
-    class Client:
-        def __init__(self, pool_size=4):
+    class TestClient(Client):
+        def __init__(self, pool_size: int = 4):
             self._pool = MemcachePool(
                 minsize=pool_size, maxsize=pool_size,
                 **mcache_params)
 
         @acquire
-        async def acquire_wait_release(self, conn):
+        async def acquire_wait_release(self, conn: Connection) -> str:
             assert self._pool.size() <= pool_size
             await asyncio.sleep(random.uniform(0.01, 0.02))  # noqa: S311
             return "foo"
 
     pool_size = 4
-    client = Client(pool_size=pool_size)
+    client = TestClient(pool_size=pool_size)
     tasks = [
         asyncio.wait_for(
             client.acquire_wait_release(),
@@ -123,7 +123,7 @@ async def test_acquire_task_cancellation(
 
 
 @pytest.mark.asyncio
-async def test_maxsize_greater_than_minsize(mcache_params):
+async def test_maxsize_greater_than_minsize(mcache_params: McacheParams) -> None:
     pool = MemcachePool(minsize=5, maxsize=1, **mcache_params)
     conn = await pool.acquire()
     assert isinstance(conn.reader, asyncio.StreamReader)
@@ -132,7 +132,7 @@ async def test_maxsize_greater_than_minsize(mcache_params):
 
 
 @pytest.mark.asyncio
-async def test_0_minsize(mcache_params):
+async def test_0_minsize(mcache_params: McacheParams) -> None:
     pool = MemcachePool(minsize=0, maxsize=5, **mcache_params)
     conn = await pool.acquire()
     assert isinstance(conn.reader, asyncio.StreamReader)
@@ -141,7 +141,7 @@ async def test_0_minsize(mcache_params):
 
 
 @pytest.mark.asyncio
-async def test_bad_connection(mcache_params):
+async def test_bad_connection(mcache_params: McacheParams) -> None:
     pool = MemcachePool(minsize=5, maxsize=1, **mcache_params)
     pool._host = "INVALID_HOST"
     assert pool.size() == 0


### PR DESCRIPTION
This is a possible solution for typing, by providing a `FlagClient` (we can rename it) and a basic (backwards-compatible) `Client`.

There are 2 legitimate errors highlighted by mypy, so these will still need to be looked at.